### PR TITLE
feat: connect be to fe dataflow

### DIFF
--- a/app/components/layouts/bundle-layout.tsx
+++ b/app/components/layouts/bundle-layout.tsx
@@ -24,7 +24,7 @@ export function BundleLayout({ children, userId }: BundleLayoutProps) {
   return (
     <div className="flex flex-col w-full h-full pt-20 sm:overflow-y-scroll">
       <div className="absolute top-6 left-26 z-20 w-auto">
-        <NavLink to={'/results'}>
+        <NavLink to={`/results?userId=${userId}`}>
           <IconChevronLeft width={isMobile ? 10 : 24} />
         </NavLink>
       </div>

--- a/app/features/bundle/hooks/use-get-bundle.ts
+++ b/app/features/bundle/hooks/use-get-bundle.ts
@@ -19,7 +19,7 @@ async function getBundle(payload: GetBundlePayload): Promise<Bundle> {
   if (!response.ok) {
     throw new Error('Failed to get bundle products');
   }
-  return response.json();
+  return await response.json();
 }
 
 export function useGetBundle() {

--- a/app/features/questionnaire/questionnaire-router.tsx
+++ b/app/features/questionnaire/questionnaire-router.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
@@ -8,7 +8,7 @@ import { useConfig } from '~/context/config-context';
 import { useMainFormContext } from '~/context/main-form-context';
 import { useSnackbar } from '~/context/snackbar-context';
 import LoadingScreen from '~/features/loading-screen/loading-screen';
-import { useGetResults } from '~/features/results/hooks/use-results-hook';
+import { usePostResults } from '~/features/results/hooks/use-results-hook';
 import { QuestinnaireTypes } from '~/types/questionnaires-enum';
 
 import CameraAnalysis from '../camera-analysis/camera-analysis';
@@ -28,7 +28,7 @@ export function QuestionnaireRouter() {
   const { data: questions, isPending } = useQuestionsQuery();
   const { i18n } = useTranslation();
   const { config } = useConfig();
-  const getResults = useGetResults();
+  const postResults = usePostResults();
   const navigate = useNavigate();
   const { showError } = useSnackbar();
 
@@ -107,7 +107,7 @@ export function QuestionnaireRouter() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [questionIndex, questions, i18n.language, isSubmitting]);
 
-  if (isPending || getResults.isPending || isSubmitting) {
+  if (isPending || postResults.isPending || isSubmitting) {
     return <LoadingScreen />;
   }
 
@@ -137,7 +137,7 @@ export function QuestionnaireRouter() {
         config: config,
         answers: mergedAnswers,
       };
-      getResults.mutate(payload, {
+      postResults.mutate(payload, {
         onError: (error) => {
           setIsSubmitting(false);
           hasSubmittedRef.current = false; // Reset on error so user can retry
@@ -148,7 +148,7 @@ export function QuestionnaireRouter() {
         onSuccess: (resultData) => {
           console.log('Results:', resultData);
           setIsSubmitting(false);
-          navigate('/results', { state: { results: resultData } });
+          navigate(`/results?userId=${resultData.user_id}`);
         },
       });
     } catch (error) {

--- a/app/features/results/components/product-tile.tsx
+++ b/app/features/results/components/product-tile.tsx
@@ -1,6 +1,6 @@
 import { Typography, useMediaQuery } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 
 import type { Match, Product } from '~/features/results/types';
 import theme from '~/styles/theme';
@@ -10,7 +10,6 @@ import AvailabilityLight from '../../../components/ui/availability-light';
 
 interface ProductTileProps {
   product: Product;
-  userId?: string;
 }
 
 export function ProductTile({ match }: { match: Match }) {
@@ -129,12 +128,12 @@ export function ProductTileHorizontal({ product }: ProductTileProps) {
   );
 }
 
-export function ProductTileHorizontalRanked({
-  product,
-  userId,
-}: ProductTileProps) {
+export function ProductTileHorizontalRanked({ product }: ProductTileProps) {
   const { image, brand, description, type, price, id, rank, availability } =
     product;
+
+  const [searchParams] = useSearchParams();
+  const userId = searchParams.get('userId');
 
   const navigate = useNavigate();
   const handleOnClickProduct = () => {

--- a/app/features/results/hooks/use-results-hook.ts
+++ b/app/features/results/hooks/use-results-hook.ts
@@ -1,9 +1,15 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { postResults } from '../result-api';
+import { getResultsByUserId, postResults } from '../result-api';
 
-export function useGetResults() {
+export function usePostResults() {
   return useMutation({
     mutationFn: postResults,
+  });
+}
+
+export function useGetResultsByUserId() {
+  return useMutation({
+    mutationFn: getResultsByUserId,
   });
 }

--- a/app/features/results/result-api.ts
+++ b/app/features/results/result-api.ts
@@ -1,5 +1,7 @@
 import type { Result } from '~/features/results/types';
 
+const LOCAL_STORAGE_KEY_PREFIX = 'results_';
+
 export async function postResults(payload: any): Promise<Result> {
   const url = `${import.meta.env.VITE_BACKEND_CLOUD_URL}/get_results`;
   const response = await fetch(url, {
@@ -15,7 +17,14 @@ export async function postResults(payload: any): Promise<Result> {
   return response.json();
 }
 
-export async function getResultsByUserId(userId: string): Promise<Result> {
+export async function getResultsByUserId(userId?: string): Promise<Result> {
+  const storageKey = LOCAL_STORAGE_KEY_PREFIX + userId;
+  const cached = localStorage.getItem(storageKey);
+
+  if (cached) {
+    return JSON.parse(cached);
+  }
+
   const url = `${import.meta.env.VITE_BACKEND_CLOUD_URL}/get_results_by_user_id/${userId}`;
   const response = await fetch(url, {
     method: 'GET',
@@ -26,5 +35,13 @@ export async function getResultsByUserId(userId: string): Promise<Result> {
   if (!response.ok) {
     throw new Error('Failed to get results');
   }
-  return await response.json();
+  const data = await response.json();
+
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(data));
+  } catch {
+    console.error('Failed cache results on localStorage');
+  }
+
+  return data;
 }

--- a/app/features/results/result-api.ts
+++ b/app/features/results/result-api.ts
@@ -1,6 +1,6 @@
-// ...existing code...
+import type { Result } from '~/features/results/types';
 
-export async function postResults(payload: any): Promise<any> {
+export async function postResults(payload: any): Promise<Result> {
   const url = `${import.meta.env.VITE_BACKEND_CLOUD_URL}/get_results`;
   const response = await fetch(url, {
     method: 'POST',
@@ -13,4 +13,18 @@ export async function postResults(payload: any): Promise<any> {
     throw new Error('Failed to post results');
   }
   return response.json();
+}
+
+export async function getResultsByUserId(userId: string): Promise<Result> {
+  const url = `${import.meta.env.VITE_BACKEND_CLOUD_URL}/get_results_by_user_id/${userId}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error('Failed to get results');
+  }
+  return await response.json();
 }

--- a/app/features/results/results-screen-vertical.tsx
+++ b/app/features/results/results-screen-vertical.tsx
@@ -1,7 +1,7 @@
 import { Typography } from '@mui/material';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 
 import { SmallLarge } from '~/components/layouts/small-large';
 import { DefaultButton } from '~/components/ui/default-button';
@@ -27,11 +27,12 @@ export function ResultsScreenVertical({
 }: ResultsScreenVerticalProps) {
   const numberOfProductsToShow = 3;
   const { t } = useTranslation();
-  const location = useLocation();
   const navigate = useNavigate();
   const userFlowExitMutation = useUserFlowExit();
 
-  const userId = location.state?.results?.user_id;
+  const [searchParams] = useSearchParams();
+  const userId = searchParams.get('userId');
+
   const { filters, setFilters, clearAllFilters, hasActiveFilters } =
     useFilters();
 
@@ -116,7 +117,6 @@ export function ResultsScreenVertical({
                   availability: match.availability,
                   rank: index + 1,
                 }}
-                userId={userId}
               />
             ))}
           </div>

--- a/app/features/results/types.ts
+++ b/app/features/results/types.ts
@@ -1,5 +1,11 @@
-
 export type Availability = 'available' | 'online' | 'unavailable' | 'unknown';
+
+export type ProductType =
+  | 'BB-cream and CC-cream'
+  | 'concealer'
+  | 'foundation'
+  | 'highlighter'
+  | 'powder';
 
 export type Match = {
   image: string;
@@ -14,3 +20,31 @@ export type Product = {
   id: string;
   rank: number;
 } & Match;
+
+type Client = {
+  color: string;
+};
+
+export type RecommendedProduct = {
+  product_brand_name: string;
+  product_description: string;
+  product_color_swatch: string;
+  type: string;
+  price: string;
+  product_image: string;
+  product_link: string;
+  erp_connection: boolean;
+  instore_status: boolean;
+  online_status: boolean;
+  stock_level: number;
+  match_percentage: string;
+  product_id: string;
+};
+
+export type Result = {
+  user_id: string;
+  timestamp: string;
+  client: Client;
+  products: RecommendedProduct[];
+  product_types: ProductType[];
+};

--- a/app/features/results/utils/result-translate.ts
+++ b/app/features/results/utils/result-translate.ts
@@ -1,19 +1,4 @@
-interface Product {
-  product_brand_name: string;
-  product_description: string;
-  product_color_swatch: string;
-  type: string;
-  price: string;
-  product_image: string;
-  product_link: string;
-  erp_connection: boolean;
-  instore_status: boolean;
-  online_status: boolean;
-  stock_level: number;
-  match_percentage: string;
-  product_id: string;
-  properties: Record<string, string[]>;
-}
+import type { RecommendedProduct } from '~/features/results/types';
 
 export interface Match {
   product_id: string;
@@ -26,7 +11,9 @@ export interface Match {
   gtin: string;
 }
 
-export function translateProductsToMatches(products: Product[]): Match[] {
+export function translateProductsToMatches(
+  products: RecommendedProduct[],
+): Match[] {
   return products.map((product) => {
     let availability: 'available' | 'online' | 'unavailable' | 'unknown';
 

--- a/app/routes/bundle.tsx
+++ b/app/routes/bundle.tsx
@@ -4,7 +4,6 @@ import { useParams, useSearchParams } from 'react-router';
 import { BundleLayout } from '~/components/layouts/bundle-layout';
 import { BundleScreen } from '~/features/bundle/bundle-screen';
 import { useGetBundle } from '~/features/bundle/hooks/use-get-bundle';
-import { mockBundle } from '~/features/bundle/mockData/bundle';
 import LoadingScreen from '~/features/loading-screen/loading-screen';
 
 export default function Bundle() {
@@ -19,15 +18,13 @@ export default function Bundle() {
     }
   }, [fetchBundle, productId, userId]);
 
-  const bundle = data ?? mockBundle;
-
-  if (isPending) {
+  if (isPending || !userId || !data) {
     return <LoadingScreen />;
   }
 
   return (
-    <BundleLayout userId={userId ?? ''}>
-      <BundleScreen bundle={bundle} />
+    <BundleLayout userId={userId}>
+      <BundleScreen bundle={data} />
     </BundleLayout>
   );
 }

--- a/app/routes/results.tsx
+++ b/app/routes/results.tsx
@@ -1,7 +1,9 @@
-import { Navigate, useLocation } from 'react-router';
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router';
 
 import { ResultLayout } from '~/components/layouts/result-layout';
-import { mockResults } from '~/features/results/mockData/results';
+import LoadingScreen from '~/features/loading-screen/loading-screen';
+import { useGetResultsByUserId } from '~/features/results/hooks/use-results-hook';
 import ResultsScreenVertical from '~/features/results/results-screen-vertical';
 import { translateProductsToMatches } from '~/features/results/utils/result-translate';
 
@@ -12,20 +14,24 @@ const mockAnalysisResults = [
 ];
 
 const ResultsPage = () => {
-  const location = useLocation();
-  const results = location.state?.results ?? mockResults;
+  const [searchParams] = useSearchParams();
+  const userId = searchParams.get('userId');
+  const { mutate: fetchResults, data, isPending } = useGetResultsByUserId();
 
-  if (!results) {
-    // Redirect to a fallback page if no data is passed
-    return <Navigate to="/" />;
+  useEffect(() => {
+    if (userId) {
+      fetchResults(userId);
+    }
+  }, [fetchResults, userId]);
+
+  if (isPending || !data) {
+    return <LoadingScreen />;
   }
-  console.log('Results:', results);
 
-  // const matches = translateProductsToMatches(results.products).slice(0, 10);
-  const matches = translateProductsToMatches(results.products);
+  const matches = translateProductsToMatches(data.products);
 
   return (
-    <ResultLayout userId={results.user_id}>
+    <ResultLayout userId={data.user_id}>
       <ResultsScreenVertical
         analysisResults={mockAnalysisResults}
         topMatches={matches}


### PR DESCRIPTION
- Passes userId as a search parameter in the url to also being able to get results in mobile
- Adds another API call for get_results_by_user_id
- Since the API response is huge for this endpoint with 100 products - I decided to cache the results because otherwise, navigating through pages fetches this results again, and the user ends up waiting for second till the page fully loads
- This still happens on the first load - so I'd highly suggest reducing the size of the response object from BE
- Now after caching in local storage, we don't have to refetch and it works fast after the first load (user must have cache enabled for this to work)
- Currently it might be an overkill to introduce a state management in the app since there are only a few endpoint, but if the app grows I'd also recommend adding it at some point.

You can see below in the demo how long it takes to load it initially in the results page with a new user id and how it works afterwards, I also tested the feedback endpoint and it seems to be working


https://github.com/user-attachments/assets/3a2cc921-2550-4dc7-b39d-f36538845e34


