### PR TITLE
feat: save filters on navigation

### DIFF
--- a/app/features/results/components/product-filters-mobile.tsx
+++ b/app/features/results/components/product-filters-mobile.tsx
@@ -1,5 +1,5 @@
-import { Button, Box, SwipeableDrawer } from '@mui/material';
-import { type Dispatch, type SetStateAction, useState } from 'react';
+import { Box, Button, SwipeableDrawer } from '@mui/material';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { IconCross } from '~/components/ui/icons';
@@ -10,7 +10,7 @@ import theme from '~/styles/theme';
 
 type ProductFiltersMobileProps = {
   filters: FilterState;
-  setFilters: Dispatch<SetStateAction<FilterState>>;
+  setFilters: (newFilters: Partial<FilterState>) => void;
   clearAllFilters: () => void;
   hasActiveFilters: boolean;
 };
@@ -85,9 +85,7 @@ export function ProductFiltersMobile({
               <MultiSelectFilter
                 key={key}
                 filter={filters[key as keyof FilterState]}
-                setFilter={(value: string) =>
-                  setFilters((prev) => ({ ...prev, [key]: value }))
-                }
+                setFilter={(value: string) => setFilters({ [key]: value })}
                 labelKey={config.labelKey}
                 optionKeys={config.optionKeys}
               />

--- a/app/features/results/components/product-filters.tsx
+++ b/app/features/results/components/product-filters.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@mui/material';
-import type { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { MultiSelectFilter } from '~/features/results/components/multi-select-filter';
@@ -8,7 +7,7 @@ import type { FilterState } from '~/features/results/hooks/use-filters-hook';
 
 export type ProductFiltersProps = {
   filters: FilterState;
-  setFilters: Dispatch<SetStateAction<FilterState>>;
+  setFilters: (newFilters: Partial<FilterState>) => void;
   clearAllFilters: () => void;
   hasActiveFilters: boolean;
 };
@@ -28,9 +27,7 @@ export function ProductFilters({
           <MultiSelectFilter
             key={key}
             filter={filters[key as keyof FilterState]}
-            setFilter={(value: string) =>
-              setFilters((prev) => ({ ...prev, [key]: value }))
-            }
+            setFilter={(value: string) => setFilters({ [key]: value })}
             labelKey={config.labelKey}
             optionKeys={config.optionKeys}
           />

--- a/app/features/results/hooks/use-filters-hook.ts
+++ b/app/features/results/hooks/use-filters-hook.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 export interface FilterState {
   coverage: string[];
@@ -6,16 +6,36 @@ export interface FilterState {
   others: string[];
 }
 
+const FILTERS_KEY = 'app_filters';
+
 export function useFilters(initialState?: Partial<FilterState>) {
-  const [filters, setFilters] = useState<FilterState>({
-    coverage: [],
-    category: [],
-    others: ['Available'],
-    ...initialState,
+  const [filters, setFiltersState] = useState<FilterState>(() => {
+    try {
+      const saved = localStorage.getItem(FILTERS_KEY);
+      if (saved) return JSON.parse(saved) as FilterState;
+    } catch (e) {
+      console.warn('Failed to parse saved filters:', e);
+    }
+    return {
+      coverage: [],
+      category: [],
+      others: ['Available'],
+      ...initialState,
+    };
   });
 
+  useEffect(() => {
+    localStorage.setItem(FILTERS_KEY, JSON.stringify(filters));
+  }, [filters]);
+
+  const setFilters = (newFilters: Partial<FilterState>) => {
+    setFiltersState((prev) => ({ ...prev, ...newFilters }));
+  };
+
   const clearAllFilters = () => {
-    setFilters({ coverage: [], category: [], others: [] });
+    const cleared = { coverage: [], category: [], others: [] };
+    setFiltersState(cleared);
+    localStorage.removeItem(FILTERS_KEY);
   };
 
   const hasActiveFilters = useMemo(


### PR DESCRIPTION
Hey hey, as we discussed yesterday that you want to keep the filters persistent through page navigation, I stored them also in local storage. This could not be the best solution but it's the easiest and quickest considering we have a super limited time left.

Some possible issues with this could be:

- The mechanism we use **localStorage** is persistent which means that the data stays until it is explicitly removed, it can survive page refreshes, browser restarts. This means let's say the customer first opened the results on Monday, set some filters and then left the page, after some days she came back and  opened the results again, the filters could still be there and applied - which I'm not sure a behavior you want.

- Also for some users/browsers cache could be disabled and this would result in filters being lost on navigation through pages.

One another option would be to store the filters as search parameters on the URL. like 
`/results?userId=1&category=foundation`, get them from there and add to filter state.

Since the time is limited I couldn't try the second option, but we can discuss in our call today if you want.


